### PR TITLE
Update whcsc31st info

### DIFF
--- a/generic.html
+++ b/generic.html
@@ -49,7 +49,7 @@
 					<h2><span class="element2"></span></h2>
 					<script>
 						var typed = new Typed('.element2', {
-							strings: ["<strong>2021</strong>", "<strong>電研要贏</strong>", "<strong>2021文華電研幹部名單</strong>"],  typeSpeed: 15, backSpeed: 10//输入内容, 支持html标签 //回退速度 smartBackspace: true 
+							strings: ["<strong>2023</strong>", "<strong>電研要贏</strong>", "<strong>2023文華電研幹部名單</strong>"],  typeSpeed: 15, backSpeed: 10//输入内容, 支持html标签 //回退速度 smartBackspace: true 
                                                         }); 
                                         </script>
 			        </div>
@@ -78,8 +78,22 @@
 					}
 					</script>
 					<div id="doc" class="markdown-body container-fluid comment-enabled" data-hard-breaks="true" style="position: relative;">
-						<h1 id="文華電研幹部名單-2021">文華電研幹部名單 2022</h1>
+						<h1 id="文華電研幹部名單-2023">文華電研幹部名單 2023</h1>
 						<h2 id="本屆幹部">本屆幹部</h2>
+						<blockquote>
+							<h2 id="WHCSC-31-114級；WH34"><strong>WHCSC 31 (114級；WH34)</strong></h2> </blockquote>
+						<p>(2023年8月—2024年8月)，是文華高中電腦資訊研習社的第三十一屆，文華電研滿30歲。</p>
+						<ul>
+							<li>社長/教學(資安) : 蔡承育(<a href="https://www.instagram.com/denmis1080142/">denmis1080142</a>) </li>
+							<li>副社長 : 林俊廷 </li>
+							<li>網管/教學(C++) : 孫驊辰(<a href="https://www.instagram.com/raysun96_ray/">raysun96_ray</a>) </li>
+							<li>美宣/公關 : 賴顗安(<a href="https://www.instagram.com/yian188/">yian188</a>)</li>
+						</ul>
+						<hr>
+						<ul>
+							<li>2024中部電資聯合寒訓：知資為資知<a href="https://www.instagram.com/scaict.2024_wintercamp/" target="_blank" rel="noopener">IG</a></li>
+						</ul>
+						<h2 id="退休幹部">退休幹部</h2>
 						<blockquote>
 							<h2 id="WHCSC-30-113級；WH33"><strong>WHCSC 30 (113級；WH33)</strong></h2> </blockquote>
 						<p>(2022年8月—2023年8月)，是文華高中電腦資訊研習社的第三十屆，文華電研滿29歲。</p>
@@ -92,7 +106,6 @@
 							<li>公關 : 梁昀祈 </li>
 						</ul>
 						<hr>
-						<h2 id="退休幹部">退休幹部</h2>
 						<blockquote>
 							<h2 id="WHCSC-29-112級；WH32"><strong>WHCSC 29 (111級；WH32)</strong></h2> </blockquote>
 							<p>(2021年8月—2022年8月)，是文華高中電腦資訊研習社的第二十九屆，文華電研滿28歲。</p>
@@ -756,10 +769,10 @@
 								href="mailto: club_computer@whsh.tc.edu.tw">club_computer<br>@whsh.tc.edu.tw</a></li>
 						<li class="icon brands fa-facebook-f"><a
 								href="https://www.facebook.com/whcsc29th/">文華電腦研究社
-								computers studying club）</a></li>
+								（whsh computers studying club）</a></li>
 						<li class="icon brands fa-instagram"><a
-								href="https://www.instagram.com/whcsc29th/">whcsc29th</a></li>
-					</ul>
+								href="https://www.instagram.com/whcsc31st/">whcsc31st</a></li>
+							</ul>
 	
 				</div>
 			</section>

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 					<a href="story/index.html" class="image"><img src="images/pic01.jpg" alt="" /></a>
 					<div class="content">
 						<h2 class="major">我們的故事</h2>
-						<p>文華電研成立於民國82年，迄今走過30個年頭，孕育不少有理想、有熱情、有才幹的人才，更不知啟發了多少文華學子對於資訊領域的熱忱， 一路走來我們有起有落，有風光的時刻，也有困難的時期…
+						<p>文華電研成立於民國82年，迄今走過32個年頭，孕育不少有理想、有熱情、有才幹的人才，更不知啟發了多少文華學子對於資訊領域的熱忱， 一路走來我們有起有落，有風光的時刻，也有困難的時期…
 						</p>
 						<a href="story/index.html" class="special">更多</a>
 					</div>
@@ -95,14 +95,12 @@
 					<a href="generic.html" class="image"><img src="images/pic02.jpg" alt="" /></a>
 					<div class="content">
 						<h2 class="major">幹部&社師介紹</h2>
-						<p>第30屆社團共有6位幹部
-							<li>社團老師 : 廖偉良 </li>
-							<li>社長/教學 : 王崇翰(Han09057) </li>
-							<li>副社長 : 曲品劭(redwingfatfat) </li>
-							<li>總務/文書 : 賴仕臻(jettyi) </li>
-							<li>教學/美宣 : 吳驊恩(wu-sususu) </li>
-							<li>網管 : 林毓琦(alexlin0517) </li>
-							<li>公關 : 梁昀祈 </li>
+						<p>第31屆社團共有4位幹部
+							<li>社團老師 : 張傑富 </li>
+							<li>社長/教學(資安) : 蔡承育(<a href="https://www.instagram.com/denmis1080142/">denmis1080142</a>) </li>
+							<li>副社長 : 林俊廷 </li>
+							<li>網管/教學(C++) : 孫驊辰(<a href="https://www.instagram.com/raysun96_ray/">raysun96_ray</a>) </li>
+							<li>美宣/公關 : 賴顗安(<a href="https://www.instagram.com/yian188/">yian188</a>)</li>
 						</p>
 						<a href="generic.html" class="special">更多</a>
 					</div>
@@ -116,8 +114,10 @@
 			<section id="four" class="wrapper style2">
 				<div class="inner">
 					<h2 class="major">課程介紹</h2>
-					課程總共主要分為三大類:<br>
-					python/C++/discord bot<br><br>
+					課程總共主要分為兩大類:<br>
+					<li>資安(CTF/滲透測試)</li>
+					<li>C++(Arduino/競程)</li>
+					<br><br>
 					偶們ㄉdiscord: <a href="https://discord.gg/ad7gaTw">https://discord.gg/ad7gaTw</a>
 						
 					</div>
@@ -138,9 +138,9 @@
 							href="mailto: club_computer@whsh.tc.edu.tw">club_computer<br>@whsh.tc.edu.tw</a></li>
 					<li class="icon brands fa-facebook-f"><a
 							href="https://www.facebook.com/whcsc29th/">文華電腦研究社
-							computers studying club）</a></li>
+							（whsh computers studying club）</a></li>
 					<li class="icon brands fa-instagram"><a
-							href="https://www.instagram.com/whcsc29th/">whcsc29th</a></li>
+							href="https://www.instagram.com/whcsc31st/">whcsc31st</a></li>
 				</ul>
 
 			</div>


### PR DESCRIPTION
### Summary
- 修改或新增`index.html`與`generic.html`中31st的幹部名單、課程內容、社團年齡
- 移動30屆至退休幹部
- 調整FB與IG連結

### Unchanged
- 錯字(如括號等)
- 疑似錯誤資訊(如：112級打成111級等)